### PR TITLE
Add support contact information to app routes

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Home, FileText, CreditCard, Sparkles } from "lucide-react"
+import { Home, FileText, CreditCard, Sparkles, HelpCircle } from "lucide-react"
 import { Link, useNavigate } from "react-router-dom"
 import { supabase } from "@/lib/supabase"
 import { getUserResumes } from "@/lib/uploadResume"
@@ -69,6 +69,11 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
       title: "Billing",
       url: "/app/billing-details",
       icon: CreditCard,
+    },
+    {
+      title: "Support",
+      url: "/support",
+      icon: HelpCircle,
     },
   ]
 

--- a/frontend/src/components/nav-user.tsx
+++ b/frontend/src/components/nav-user.tsx
@@ -2,6 +2,7 @@ import {
   ChevronsUpDown,
   CreditCard,
   LogOut,
+  HelpCircle,
 } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 
@@ -100,6 +101,10 @@ export function NavUser({
               <DropdownMenuItem onClick={() => navigate('/app/billing')}>
                 <CreditCard />
                 Billing
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => navigate('/support')}>
+                <HelpCircle />
+                Support
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />


### PR DESCRIPTION
Add "Support" menu item to both the AppSidebar navigation and NavUser dropdown menu to provide users with easy access to support resources. The support page includes FAQ and contact email (support@resumefy.com placeholder).

Changes:
- AppSidebar: Added Support navigation item with HelpCircle icon linking to /support
- NavUser dropdown: Added Support menu item in user dropdown alongside Billing
- Uses shadcn components and maintains design consistency
- Provides dual access points following SaaS best practices