### PR TITLE
Fix resume parser missing skill sections

### DIFF
--- a/backend/supabase/functions/_shared/prompts.ts
+++ b/backend/supabase/functions/_shared/prompts.ts
@@ -81,6 +81,7 @@ WHAT "TAILORING" DOES NOT MEAN:
 - ❌ Cutting down content to fit one page (our PDF handles layout)
 - ❌ Filtering out older experience or education
 - ❌ Dropping technical details or tools/frameworks
+- Only REMOVE/MINIMIZE truly irrelevant details (e.g., unrelated hobbies)
 
 Key principles:
 - NEVER remove content unless it's duplicate or clearly a formatting artifact
@@ -92,7 +93,10 @@ Key principles:
 - Extract ALL skills (technical AND soft skills)
 - Extract ALL certifications, awards, publications
 - QUANTIFY achievements when possible (numbers, percentages, scale)
-- MIRROR the JD's language style and terminology`,
+- PRIORITIZE content that directly matches job requirements (9-10 priority)
+- MIRROR the JD's language style and terminology
+- ALWAYS EXTRACT all major resume sections (contact, summary, experience, education, skills, projects, certifications) even if some have lower relevance
+- Only omit truly irrelevant sections like hobbies/interests that don't relate to the job`,
 
     user: (resumeText: string, jobDescription: string, jobTitle: string, compatibilityInsights: any) => `
 JOB TITLE: ${jobTitle}
@@ -117,6 +121,8 @@ INSTRUCTIONS:
 6. Extract EVERY section that exists - do not skip content
 7. Preserve all factual information (dates, names, numbers, achievements, technologies)
 8. CONTENT PRESERVATION MINIMUM: If a job has 6 bullets in original resume, include at least 5 in tailored version (85% minimum)
+9. For SKILLS: Extract as a simple array of skill strings, not nested objects (renders better in PDF)
+10. For PROJECTS: Always include if they exist, even with moderate priority (6-8)
 
 🚨 CRITICAL COUNTING RULE:
 Count the experience bullets, projects, and skills in the original resume.
@@ -182,10 +188,7 @@ Return JSON with this structure:
       "id": "skills-1",
       "category": "skills",
       "priority": 9,
-      "content": {
-        "title": "Technical Skills",
-        "items": ["Python", "Azure", "Docker", "SQL"]
-      }
+      "content": ["Python", "Azure", "Docker", "SQL", "Kubernetes", "React"]
     },
     {
       "id": "certifications-1",
@@ -204,7 +207,11 @@ Return JSON with this structure:
       "priority": 8,
       "content": {
         "title": "E-commerce Platform",
-        "description": "Built scalable platform using Python and Azure...",
+        "description": "Built scalable platform using Python and Azure",
+        "bullets": [
+          "Architected microservices backend handling 100K+ daily transactions",
+          "Implemented CI/CD pipeline reducing deployment time by 60%"
+        ],
         "technologies": ["Python", "Azure", "React"],
         "link": "github.com/user/project"
       }
@@ -429,11 +436,13 @@ Limit to 4-6 recommendations. Be specific and actionable.`
 Your goals:
 1. Respect template constraints (column structure, max lines, spacing)
 2. Prioritize high-priority blocks (9-10) at the top
-3. Create logical flow (contact → summary → experience → education → skills)
+3. Create logical flow (contact → summary → experience → education → skills → projects → certifications)
 4. Balance visual weight across columns (for two-column templates)
 5. Ensure critical information is above the fold (first page)
+6. INCLUDE all major sections (experience, education, skills, projects, certifications) even if some have moderate priority (6-8)
+7. Only omit truly irrelevant sections like hobbies/interests that don't relate to professional qualifications
 
-Consider both ATS compatibility and human readability.`,
+Consider both ATS compatibility and human readability. A complete resume with all relevant sections is better than a sparse one.`,
 
     user: (blocks: any, templateName: string, templateConstraints: any) => `
 TEMPLATE: ${templateName}
@@ -459,7 +468,9 @@ Return JSON with this structure:
 
 For single-column templates, use only "header" and "main" sections.
 For two-column templates, balance content between "main" (left, 60-70% width) and "sidebar" (right, 30-40% width).
-Prioritize blocks with priority ≥ 8 for above-the-fold placement.`
+Prioritize blocks with priority ≥ 8 for above-the-fold placement.
+IMPORTANT: Include ALL major sections (experience, education, skills, projects, certifications) in the layout.
+Only omit sections like hobbies/interests if they are truly irrelevant to the job.`
   }
 }
 

--- a/backend/supabase/functions/generate-tailored-resume/renderPDF.ts
+++ b/backend/supabase/functions/generate-tailored-resume/renderPDF.ts
@@ -219,21 +219,45 @@ function renderTemplateA(blocks: ContentBlock[], layout: LayoutDecision): any {
     // SKILLS BLOCK
     else if (block.category === 'skills') {
       console.log('📄 Rendering skills:', block.content)
-      content.push({
-        text: 'SKILLS',
-        style: 'sectionTitle',
-        margin: [0, 5, 0, 10]
-      })
+
+      if (!sectionsAdded.has('skills')) {
+        content.push({
+          text: 'SKILLS',
+          style: 'sectionTitle',
+          margin: [0, 5, 0, 10]
+        })
+        sectionsAdded.add('skills')
+      }
+
+      // Handle multiple skill formats
+      let skillsText = ''
 
       if (Array.isArray(block.content)) {
-        content.push({
-          text: block.content.join(' • '),
-          style: 'skills',
-          margin: [0, 0, 0, 15]
-        })
+        // Format: ["Python", "Azure", "Docker"]
+        skillsText = block.content.join(' • ')
       } else if (typeof block.content === 'string') {
+        // Format: "Python, Azure, Docker"
+        skillsText = block.content
+      } else if (block.content && typeof block.content === 'object') {
+        // Format: { title: "Technical Skills", items: ["Python", "Azure"] }
+        // OR: { items: ["Python", "Azure"] }
+        if (block.content.title) {
+          content.push({
+            text: block.content.title,
+            style: 'jobTitle',
+            margin: [0, 0, 0, 3]
+          })
+        }
+        if (Array.isArray(block.content.items)) {
+          skillsText = block.content.items.join(' • ')
+        } else if (typeof block.content.items === 'string') {
+          skillsText = block.content.items
+        }
+      }
+
+      if (skillsText) {
         content.push({
-          text: block.content,
+          text: skillsText,
           style: 'skills',
           margin: [0, 0, 0, 15]
         })
@@ -261,6 +285,7 @@ function renderTemplateA(blocks: ContentBlock[], layout: LayoutDecision): any {
           margin: [0, 0, 0, 3]
         })
 
+        // Handle description (paragraph format)
         if (proj.description) {
           content.push({
             text: proj.description,
@@ -269,6 +294,16 @@ function renderTemplateA(blocks: ContentBlock[], layout: LayoutDecision): any {
           })
         }
 
+        // Handle bullets (list format)
+        if (Array.isArray(proj.bullets) && proj.bullets.length > 0) {
+          content.push({
+            ul: proj.bullets,
+            style: 'bulletList',
+            margin: [0, 0, 0, 5]
+          })
+        }
+
+        // Handle technologies
         if (proj.technologies) {
           const techText = Array.isArray(proj.technologies)
             ? proj.technologies.join(', ')
@@ -276,6 +311,15 @@ function renderTemplateA(blocks: ContentBlock[], layout: LayoutDecision): any {
 
           content.push({
             text: `Technologies: ${techText}`,
+            style: 'dates',
+            margin: [0, 0, 0, 12]
+          })
+        }
+
+        // Handle link
+        if (proj.link || proj.url) {
+          content.push({
+            text: proj.link || proj.url,
             style: 'dates',
             margin: [0, 0, 0, 12]
           })


### PR DESCRIPTION
Fixed three critical issues causing incomplete resume section extraction:

1. Layout Decision Filtering (Step 6):
   - Updated AI prompt to INCLUDE all major sections (experience, education, skills, projects, certifications) even with moderate priority (6-8)
   - Only omit truly irrelevant sections (hobbies/interests)
   - Added explicit instruction that complete resumes are better than sparse ones

2. Section Extraction (Step 2):
   - Clarified to ALWAYS EXTRACT all major sections that exist in resume
   - Changed from "REMOVE/MINIMIZE irrelevant details" to only remove "truly irrelevant details (e.g., unrelated hobbies)"
   - Added explicit instruction to include PROJECTS even with moderate priority
   - Updated SKILLS format to use simple array instead of nested object

3. Skills Rendering:
   - Fixed content structure mismatch between AI extraction and PDF rendering
   - Added support for multiple skill formats: array, string, and object with items
   - Fixed duplicate "SKILLS" headers when multiple skill blocks exist
   - Now properly handles subcategorized skills (e.g., "Technical Skills", "Hardware Knowledge")

4. Projects Rendering:
   - Added support for bullet points format (not just description)
   - Added support for project links/URLs
   - Enhanced to handle both paragraph and list formats

Files changed:
- backend/supabase/functions/_shared/prompts.ts
- backend/supabase/functions/generate-tailored-resume/renderPDF.ts